### PR TITLE
fix(version): Add the version to the path that poet will look for

### DIFF
--- a/poet/poet.py
+++ b/poet/poet.py
@@ -17,10 +17,8 @@ from hashlib import sha256
 
 from importlib.metadata import metadata
 import json
-from lib2to3.pgen2.token import OP
 import logging
 import os
-from re import S
 import shlex
 import subprocess
 import sys

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -187,8 +187,8 @@ def research_package(name: str, version=None) -> PackageMetadata:
     Returns:
         PackageMetadata: A dictionary of metadata about the package.  
     """
-    pip_source_dir = os.getenv("PIP_SOURCE_DIR")
-    if pip_source_dir:
+    pip_source_dir = Path(os.getenv("PIP_SOURCE_DIR"))
+    if pip_source_dir.is_dir():
         if not os.path.exists(pip_source_dir):
             raise PipSourceMetadataException("PIP_SOURCE_DIR does not exist: {}".format(pip_source_dir))
         pip_source_file = Path(pip_source_dir)/"{}-{}.tar.gz".format(name.lower(), version)    

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -110,7 +110,7 @@ class PackageMetadata:
         setattr(self, idx, val)
 
     
-    def get_checksums(self) -> str:
+    def get_checksums(self):
         """Given the path to a pip source file, return the files checksum.
 
         Args:

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -191,7 +191,7 @@ def research_package(name: str, version=None) -> PackageMetadata:
     if pip_source_dir:
         if not os.path.exists(pip_source_dir):
             raise PipSourceMetadataException("PIP_SOURCE_DIR does not exist: {}".format(pip_source_dir))
-        pip_source_file = Path(pip_source_dir)/"{}.tar.gz".format(name.lower())    
+        pip_source_file = Path(pip_source_dir)/"{}-{}.tar.gz".format(name.lower(), version)    
         return get_metadata_from_pip_source(pip_source_file)
 
     with closing(urlopen("https://pypi.io/pypi/{}/json".format(name))) as f:

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -155,7 +155,7 @@ class PackageMetadata:
         except Exception as e:
             raise PipSourceMetadataException(f"Could not get download URL from pip source file: {e}") from e
         
-    def get_homepage(self) -> str:
+    def get_homepage(self):
         """Get the homepage from the pip source distribution.
 
         Args:

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -147,7 +147,7 @@ class PackageMetadata:
         try:
             extractor = URLExtract()
             urls = extractor.find_urls(output.stdout)
-            self.url = [url for url in urls if self.name in url][0]
+            self.url = next(filter(lambda url: self.name in url, urls))
         except Exception as e:
             raise PipSourceMetadataException(f"Could not get download URL from pip source file: {e}") from e
         

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -99,6 +99,10 @@ class PackageMetadata:
     checksum_type: str = field(default="sha256", init=False)
     source_file: Optional[Path] = None
     version: Optional[Version] = None
+    
+    def asdict(self):
+        exclude_keys = ["version"]
+        return dict(filter(lambda x: x[0] not in exclude_keys, super().asdict()))
 
     def __getitem__(self, idx):
         try:

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -128,7 +128,7 @@ class PackageMetadata:
         
         self.checksum = sha256(self.source_file.read_bytes()).hexdigest()
    
-    def get_download_url(self) -> str:
+    def get_download_url(self):
         """
         Returns the download URL for the pip source distribution.
         This method will download the pip package from the source distribution. 

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -144,7 +144,7 @@ class PackageMetadata:
         """
         
         try:
-            output = subprocess.run(shlex.split(f"pip download --dest {output_dir} --no-binary :all: --no-deps {self.name}"), capture_output=True, text=True)
+            output = subprocess.run(shlex.split(f"pip3 download --dest {output_dir} --no-binary :all: --no-deps {self.name}"), capture_output=True, text=True)
         except subprocess.CalledProcessError as cpe:
             raise PipSourceMetadataException(f"Could not download {self.name} from pip source file: {cpe.stderr}")
         

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -17,14 +17,18 @@ from hashlib import sha256
 
 from importlib.metadata import metadata
 import json
+from lib2to3.pgen2.token import OP
 import logging
 import os
+from re import S
 import shlex
 import subprocess
 import sys
 import warnings
 from dataclasses import dataclass, field
+from typing import Optional
 
+from packaging.version import Version, parse, InvalidVersion
 
 from urlextract import URLExtract
 
@@ -91,10 +95,12 @@ class PipSourceMetadataException(Exception):
 @dataclass
 class PackageMetadata:
     name: str
-    homepage: str
-    url: str
-    checksum: str
+    homepage: str = field(optional=True)
+    download_url: Optional[str] = None
+    checksum: Optional[str] = None
     checksum_type: str = field(default="sha256", init=False)
+    source_file: Optional[Path] = None
+    version: Optional[Version] = None
 
     def __getitem__(self, idx):
         try:
@@ -105,75 +111,62 @@ class PackageMetadata:
     def __setitem__(self, idx, val):
         setattr(self, idx, val)
 
-
-
-def get_download_url_from_pip_source_file(module: str, pip_source_file: Path, output_dir: Path) -> str:
-    """
-    Returns the download URL for the pip source distribution.
-    This method will download the pip package from the source distribution. 
-
-    The standard out of this command contains an obfuscated URL and a regular URL that points to a .tar.gz file.
-
-    Arguments:
-        module (str): The name of the module to download.
-        output_dir (str): The directory to download the module to.
-
-    Returns:
-        str: The download URL for the pip source distribution.
-    """
-
-    if not output_dir.is_dir():
-        output_dir = Path(os.getenv("PIP_SOURCE_DIR"))
-    try:
-        output = subprocess.run(shlex.split(f"pip download --dest {output_dir} --no-binary :all: --no-deps {module}"), capture_output=True, text=True)
-    except subprocess.CalledProcessError as cpe:
-        raise PipSourceMetadataException(f"Could not download {module} from pip source file: {cpe.stderr}")
     
-    try:
-        extractor = URLExtract()
-        urls = extractor.find_urls(output.stdout)
-        return [url for url in urls if pip_source_file.name in url][0]
-    except Exception as e:
-        raise PipSourceMetadataException(f"Could not get download URL from pip source file: {e}") from e
+    def get_checksums(self) -> str:
+        """Given the path to a pip source file, return the files checksum.
 
-def get_checksum_from_pip_source_file(pip_source_file: Path) -> str:
-    """Given the path to a pip source file, return the files checksum.
+        Args:
+            pip_source_file (Path): The path to a .tar.gz file containing a pip source distribution.
 
-    Args:
-        pip_source_file (Path): The path to a .tar.gz file containing a pip source distribution.
+        Returns:
+            str: The checksum of the pip source file.
+        """
+        if not self.source_file.exists():
+            raise PipSourceMetadataException("File does not exist: %s" % self.source_file)
+        
+        self.checksum = sha256(self.source_file.read_bytes()).hexdigest()
+   
+    def get_download_url(self) -> str:
+        """
+        Returns the download URL for the pip source distribution.
+        This method will download the pip package from the source distribution. 
 
-    Returns:
-        str: The checksum of the pip source file.
-    """
-    if not pip_source_file.exists():
-        raise PipSourceMetadataException("File does not exist: %s" % pip_source_file)
-    
-    return sha256(pip_source_file.read_bytes()).hexdigest()
+        The standard out of this command contains an obfuscated URL and a regular URL that points to a .tar.gz file.
 
+        Arguments:
+            module (str): The name of the module to download.
+            output_dir (str): The directory to download the module to.
 
-def get_metadata_from_pip_source(pip_source_file: Path) -> PackageMetadata:
-    """Given the path to a pip source file, return a PackageMetadata object.
+        Returns:
+            str: The download URL for the pip source distribution.
+        """
+        
+        try:
+            output = subprocess.run(shlex.split(f"pip download --dest {output_dir} --no-binary :all: --no-deps {self.name}"), capture_output=True, text=True)
+        except subprocess.CalledProcessError as cpe:
+            raise PipSourceMetadataException(f"Could not download {self.name} from pip source file: {cpe.stderr}")
+        
+        try:
+            extractor = URLExtract()
+            urls = extractor.find_urls(output.stdout)
+            self.url = [url for url in urls if self.name in url][0]
+        except Exception as e:
+            raise PipSourceMetadataException(f"Could not get download URL from pip source file: {e}") from e
+        
+    def get_homepage(self) -> str:
+        """Get the homepage from the pip source distribution.
 
-    Args:
-        pip_source_file (Path): The path to a .tar.gz file containing a pip source distribution.
+        Args:
+            value (str): The value to get from metadata/
 
-    Returns:
-        PackageMetadata: A dictionary of metadata about the package required for the resource stanza.
-    """
-    if not pip_source_file.exists():
-        raise PipSourceMetadataException("File does not exist: %s" % pip_source_file)
-    
-    try:
-        metadata_object = metadata(pip_source_file)
-    except Exception as e:
-        raise PipSourceMetadataException("Could not get metadata from pip source file: %s" % e)
+        Returns:
+            PackageMetadata: A dictionary of metadata about the package required for the resource stanza.
+        """
+        try:
+            self.homepage =  metadata(self.name).get("Home-page")
+        except Exception as e:
+            raise PipSourceMetadataException("Could not get metadata from pip source file: %s" % e)
 
-    return PackageMetadata(
-        name=metadata_object.get("Name"),
-        homepage=metadata_object.get("Home-page"),
-        url=get_download_url_from_pip_source_file(metadata_object.get("Name"), pip_source_file),
-        checksum=get_checksum_from_pip_source_file(pip_source_file)
-    )
 
 def research_package(name: str, version=None) -> PackageMetadata:
     """
@@ -187,12 +180,23 @@ def research_package(name: str, version=None) -> PackageMetadata:
     Returns:
         PackageMetadata: A dictionary of metadata about the package.  
     """
+    try:
+        parsed_version = parse(version)
+    except InvalidVersion as invalid_version:
+        logging.warn("Invalid version: %s", invalid_version)
+        version = None
+
     pip_source_dir = Path(os.getenv("PIP_SOURCE_DIR"))
-    if pip_source_dir.is_dir():
-        if not os.path.exists(pip_source_dir):
-            raise PipSourceMetadataException("PIP_SOURCE_DIR does not exist: {}".format(pip_source_dir))
-        pip_source_file = Path(pip_source_dir)/"{}-{}.tar.gz".format(name.lower(), version)    
-        return get_metadata_from_pip_source(pip_source_file)
+    if pip_source_dir.is_dir() and version:
+        pip_source_file = pip_source_dir/"{}-{}.tar.gz".format(name.lower(), str(version))
+        package_metadata = PackageMetadata(name=name, version=parsed_version, source_dir=pip_source_file)
+        package_metadata.get_homepage()
+        package_metadata.get_metadata()
+        package_metadata.get_checksums()
+        package_metadata.get_download_url()
+        return package_metadata
+
+
 
     with closing(urlopen("https://pypi.io/pypi/{}/json".format(name))) as f:
         reader = codecs.getreader("utf-8")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['jinja2', 'setuptools', 'urlextract'],
+    install_requires=['jinja2', 'setuptools', 'urlextract', 'packaging'],
     entry_points={'console_scripts': [
         'poet=poet:main',
         'poet_lint=poet.lint:main',


### PR DESCRIPTION
## DO-3847 - Allow poet to check a local source dir for metadata.


Reported by @hakamadare 

```console
$ poet --resources indigoag.dev.cli
Traceback (most recent call last):
  File "/opt/pythons/versions/venv.homebrew-pypi-poet/bin/poet", line 33, in <module>
    sys.exit(load_entry_point('homebrew-pypi-poet', 'console_scripts', 'poet')())
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 373, in main
    print(resources_for([package] + args.also))
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 298, in resources_for
    nodes = merge_graphs(make_graph(p) for p in packages)
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 305, in merge_graphs
    for g in graphs:
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 298, in <genexpr>
    nodes = merge_graphs(make_graph(p) for p in packages)
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 265, in make_graph
    package_data = research_package(package, dependencies[package]['version'])
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 195, in research_package
    return get_metadata_from_pip_source(pip_source_file)
  File "/Users/stephenhuff/git/homebrew-pypi-poet/poet/poet.py", line 164, in get_metadata_from_pip_source
    raise PipSourceMetadataException("File does not exist: %s" % pip_source_file)
poet.poet.PipSourceMetadataException: File does not exist: /var/folders/g9/hzwx33s10lxdkxjmtq4_zz240000gp/T/tmp.zCnmJVVL/atlassian-python-api.tar.gz
```

This error arises from `poet` needing to get the version of the package to search for the right local gz.

This PR aims to add that version.