### PR TITLE
feat(Aws): Use AWS Code Artifact for getting source information.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -101,12 +101,12 @@ class PackageMetadata:
     source_file: Optional[Path] = None
     version: Optional[Version] = None
 
-    def __init__(self, name, version) -> None:
+    def __init__(self, name, version, repository=None, domain=None, owner=None) -> None:
         self.name = name
         self.package_name = self.name.replace(".", "-")
-        self.repository = os.getenv("AWS_CODEARTIFACT_REPOSITORY")
-        self.domain = os.getenv("AWS_CODEARTIFACT_DOMAIN")
-        self.owner = os.getenv("AWS_CODEARTIFACT_DOMAIN_OWNER")
+        self.repository = repository or os.getenv("AWS_CODEARTIFACT_REPOSITORY")
+        self.domain = domain or os.getenv("AWS_CODEARTIFACT_DOMAIN")
+        self.owner = owner or os.getenv("AWS_CODEARTIFACT_DOMAIN_OWNER")
         self.base_url = self.get_base_url()
         self.download_url = self.get_download_url()
         self.checksum = self.get_checksum()
@@ -161,7 +161,7 @@ class PackageMetadata:
             packageVersion=self.get_latest_version(),
         )
         tar_ball = [asset for asset in response["assets"] if ".tar.gz" in asset["name"]][0]
-        return tar_ball["hashes"][self.checksum_type]
+        return tar_ball["hashes"]["SHA-256"]
     
     def get_metadata(self, key: str) -> str:
         """Get the metadata from the pip source distribution.
@@ -206,7 +206,6 @@ class PackageMetadata:
                 status="Published",
                 sortBy="PUBLISHED_TIME"
             )
-            breakpoint()
             return response["versions"][0]["version"]
         except Exception as e:
             raise PackageVersionNotFoundWarning(

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -265,14 +265,14 @@ def research_package(name: str, version=None) -> PackageMetadata:
     Returns:
         PackageMetadata: A dictionary of metadata about the package.
     """
-    try:
-        parse(version)
-    except TypeError as type_error:
-        logging.warning(f"Could not parse version {version}: {type_error}")
-        version = None
-    except InvalidVersion as invalid_version:
-        logging.warn("Invalid version: %s", invalid_version)
-        version = None
+    if version is None:
+        logging.warning(f"A version was not specified for {name}. Using latest version.")
+    else:
+        try:
+            parse(version)
+        except InvalidVersion as invalid_version:
+            logging.warn("Invalid version: %s", invalid_version)
+            version = None
 
     code_artifact_repo = os.getenv("AWS_CODEARTIFACT_REPOSITORY", None)
 

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -421,6 +421,7 @@ def main():
         help="Generate resource stanzas for a package and its recursive "
         "dependencies (default).",
     )
+    parser.add_argument("--using", "-u", metavar="using", help="Add a CurlDownloadStrategy to the private resources.")
     parser.add_argument(
         "--also",
         "-a",
@@ -432,9 +433,6 @@ def main():
         "with --single. May be specified more than once.",
     )
     parser.add_argument("package", help=argparse.SUPPRESS, nargs="?")
-    parser.add_argument(
-        "--using", "-u", help="Set the strategy for the private repo urls"
-    )
     parser.add_argument(
         "-V",
         "--version",
@@ -469,7 +467,7 @@ def main():
 
         if args.using:
             logging.warning("Using private repo urls: {}".format(args.using))
-            print(resources_for([package] + args.also))
+            print(resources_for([package] + args.also, using=args.using))
         else:
             print(resources_for([package] + args.also))
     return 0

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -118,7 +118,7 @@ class PackageMetadata:
         self.download_url = self.get_base_url()
         self.checksum = self.get_checksum()
         self.checksum_type = "sha256"
-        self.url = f"{self.get_base_url()}{self.name}/{self.version}/{self.name}-{self.version}.tar.gz"
+        self.url = f"{self.get_base_url()}{self.name}/{self.get_latest_version()}/{self.name}-{self.version}.tar.gz"
         self.version = self.get_latest_version() if version is None else version
 
     def asdict(self):

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import sys
+from urllib.parse import urlparse
 import warnings
 from dataclasses import dataclass, field
 from typing import Optional
@@ -114,10 +115,10 @@ class CodeArtifactMetadata(PackageMetadata):
     def __post_init__(self):
         # If the version is not specified, get the latest version
         super().__post_init__()
+        self.client = boto3.client("codeartifact")
         if self.version is None:
             self.version = self.get_latest_version()
         self.homepage = self.get_metadata("homePage")
-        self.client = boto3.client("codeartifact")
         self.base_url = self.get_base_url()
         self.checksum = self.get_checksum()
         self.url = self.get_download_url()
@@ -143,8 +144,8 @@ class CodeArtifactMetadata(PackageMetadata):
         Returns:
             str: The download URL for the pip source distribution.
         """
-        base_url = self.get_base_url()
-        return f"{base_url}simple/{self.package_name}/{self.version}/{self.name}-{self.version}.tar.gz"
+        base_url = urlparse(f"{self.get_base_url()}simple/{self.package_name}/{self.version}/{self.name}-{self.version}.tar.gz")
+        return base_url.geturl()
 
     def get_checksum(self) -> str:
         """

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -113,10 +113,10 @@ class PackageMetadata:
         self.domain = os.getenv("AWS_CODEARTIFACT_DOMAIN")
         self.owner = os.getenv("AWS_CODEARTIFACT_DOMAIN_OWNER")
         self.base_url = self.get_base_url()
-        self.download_url = self.get_base_url()
+        self.download_url = self.get_download_url()
         self.checksum = self.get_checksum()
-        self.checksum_type = "sha256"
-        self.url = f"{self.get_base_url()}{self.name}/{self.get_latest_version()}/{self.name}-{self.version}.tar.gz"
+        self.checksum_type = "SHA-256"
+        self.url = self.get_download_url()
         self.version = self.get_latest_version() if version is None else version
 
     def asdict(self):
@@ -139,7 +139,17 @@ class PackageMetadata:
         )
         return response["repositoryEndpoint"]
 
-    def get_checksum(self, hash_type="SHA256"):
+    def get_download_url(self):
+        """Get the download URL for the pip source distribution.
+
+        Returns:
+            str: The download URL for the pip source distribution.
+        """
+        version = self.get_latest_version() if self.version is None else self.version
+        base_url = self.get_base_url() if self.base_url is None else self.base_url
+        return f"{base_url}/{self.package_name}-{version}.tar.gz"
+
+    def get_checksum(self):
         """
         Get the checksum for the pip source distribution.
 
@@ -156,7 +166,7 @@ class PackageMetadata:
             packageVersion=self.get_latest_version(),
         )
         tar_ball = [asset for asset in response["assets"] if ".tar.gz" in asset["name"]][0]
-        return tar_ball["hashes"][hash_type]
+        return tar_ball["hashes"][self.checksum_type]
     
     def get_metadata(self, key: str) -> str:
         """Get the metadata from the pip source distribution.

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -149,7 +149,7 @@ class CodeArtifactMetadata(PackageMetadata):
         try:
             return response["repositoryEndpoint"]
         except KeyError as e:
-            logging.info("Could not find key {} in response".format(e))
+            logging.warning("Could not find key {} in response".format(e))
             return None
 
     def get_download_url(self) -> str:
@@ -222,7 +222,7 @@ class CodeArtifactMetadata(PackageMetadata):
         try:
             return response["packageVersion"][key]
         except KeyError as key_error:
-            logging.info("Could not find key {} in response: {}".format(key, key_error))
+            logging.warning("Could not find key {} in response: {}".format(key, key_error))
             return None
 
     def get_latest_version(self) -> str:
@@ -249,7 +249,7 @@ class CodeArtifactMetadata(PackageMetadata):
         try:
             return response["versions"][0]["version"]
         except KeyError as key_error:
-            logging.info("Could not find latest version for {}. Error: {}".format(self.name, key_error))
+            logging.warning("Could not find latest version for {}. Error: {}".format(self.name, key_error))
             return None
 
     

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -16,6 +16,8 @@ from contextlib import closing
 from hashlib import sha256
 
 from importlib.metadata import metadata
+from pydoc import cli
+import boto3
 import json
 import logging
 import os
@@ -24,7 +26,7 @@ import subprocess
 import sys
 import warnings
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Type
 
 from packaging.version import Version, parse, InvalidVersion
 
@@ -90,31 +92,55 @@ def recursive_dependencies(package):
 class PipSourceMetadataException(Exception):
     pass
 
+
 @dataclass
 class PackageMetadata:
     name: str
-    homepage: str = field(optional=True)
+    homepage: Optional[str] = None
+    domain: Optional[str] = None
+    owner: Optional[str] = None
+    repository: Optional[str] = None
     download_url: Optional[str] = None
     checksum: Optional[str] = None
     checksum_type: str = field(default="sha256", init=False)
     source_file: Optional[Path] = None
     version: Optional[Version] = None
-    
+
+
+
+    def __init__(self, name, version) -> None:
+        self.name = name
+        self.package_name = self.name.replace(".", "-")
+        self.repository = os.getenv("AWS_CODEARTIFACT_REPOSITORY")
+        self.domain = os.getenv("AWS_CODEARTIFACT_DOMAIN")
+        self.owner = os.getenv("AWS_CODEARTIFACT_DOMAIN_OWNER")
+        self.base_url = self.get_base_url()
+        self.download_url = self.get_base_url()
+        self.checksum = self.get_checksum()
+        self.checksum_type = "sha256"
+        self.url = f"{self.get_base_url()}{self.name}/{self.version}/{self.name}-{self.version}.tar.gz"
+        self.version = self.get_latest_version() if version is None else version
+
     def asdict(self):
         exclude_keys = ["version"]
-        return dict(filter(lambda x: x[0] not in exclude_keys, super().asdict()))
+        return {k: v for k, v in self.__dict__.items() if k not in exclude_keys}
 
-    def __getitem__(self, idx):
-        try:
-            return getattr(self, idx)
-        except AttributeError as err:
-            raise KeyError(idx) from err
+    def get_base_url(self):
+        """Get the base URL for the pip source distribution.
 
-    def __setitem__(self, idx, val):
-        setattr(self, idx, val)
+        Returns:
+            str: The base URL for the pip source distribution.
+        """
+        client = boto3.client("codeartifact")
+        response = client.get_repository_endpoint(
+            domain=self.domain,
+            domainOwner=self.owner,
+            repository=self.repository,
+            format="pypi",
+        )
+        return response["repositoryEndpoint"]
 
-    
-    def get_checksums(self):
+    def get_checksum(self):
         """Given the path to a pip source file, return the files checksum.
 
         Args:
@@ -123,51 +149,68 @@ class PackageMetadata:
         Returns:
             str: The checksum of the pip source file.
         """
-        if not self.source_file.exists():
-            raise PipSourceMetadataException("File does not exist: %s" % self.source_file)
-        
-        self.checksum = sha256(self.source_file.read_bytes()).hexdigest()
-   
-    def get_download_url(self):
-        """
-        Returns the download URL for the pip source distribution.
-        This method will download the pip package from the source distribution. 
-
-        The standard out of this command contains an obfuscated URL and a regular URL that points to a .tar.gz file.
-
-        Arguments:
-            module (str): The name of the module to download.
-            output_dir (str): The directory to download the module to.
-
-        Returns:
-            str: The download URL for the pip source distribution.
-        """
-        
-        try:
-            output = subprocess.run(shlex.split(f"pip3 download --dest {output_dir} --no-binary :all: --no-deps {self.name}"), capture_output=True, text=True)
-        except subprocess.CalledProcessError as cpe:
-            raise PipSourceMetadataException(f"Could not download {self.name} from pip source file: {cpe.stderr}")
-        
-        try:
-            extractor = URLExtract()
-            urls = extractor.find_urls(output.stdout)
-            self.url = next(filter(lambda url: self.name in url, urls))
-        except Exception as e:
-            raise PipSourceMetadataException(f"Could not get download URL from pip source file: {e}") from e
-        
-    def get_homepage(self):
-        """Get the homepage from the pip source distribution.
+        client = boto3.client("codeartifact")
+        response = client.list_package_version_assets(
+            domain=self.domain,
+            domainOwner=self.owner,
+            repository=self.repository,
+            format="pypi",
+            package=self.package_name,
+            packageVersion=self.get_latest_version(),
+        )
+        tar_ball = [asset for asset in response["assets"] if ".tar.gz" in asset["name"]][0]
+        return tar_ball["hashes"]["SHA-256"]
+    
+    def get_metadata(self, key: str) -> str:
+        """Get the metadata from the pip source distribution.
 
         Args:
-            value (str): The value to get from metadata/
+            key (str): The key to get from metadata/
 
         Returns:
-            PackageMetadata: A dictionary of metadata about the package required for the resource stanza.
+            str: The value of the key.
         """
         try:
-            self.homepage =  metadata(self.name).get("Home-page")
+            client = boto3.client("codeartifact")
+            response = client.get_package_version_metadata(
+                domain=self.domain,
+                domainOwner=self.owner,
+                repository=self.repository,
+                format="pypi",
+                package=self.name,
+                packageVersion=self.get_latest_version(),
+                key=key,
+            )
+            return response[key]
         except Exception as e:
-            raise PipSourceMetadataException("Could not get metadata from pip source file: %s" % e)
+            raise PipSourceMetadataException(
+                f"Could not get metadata for {self.name} {self.version}"
+            ) from e
+    
+    def get_latest_version(self):
+        """Get the latest version of the package.
+
+        Returns:
+            Version: The latest version of the package.
+        """
+        try:
+            client = boto3.client("codeartifact")
+            response = client.list_package_versions(
+                domain=self.domain,
+                domainOwner=self.owner,
+                repository=self.repository,
+                format="pypi",
+                package=self.package_name,
+                status="Published",
+                sortBy="PUBLISHED_TIME"
+            )
+            breakpoint()
+            return response["versions"][0]["version"]
+        except Exception as e:
+            raise PackageVersionNotFoundWarning(
+                f"Could not get latest version for {self.name}: {e}"
+            ) from e
+
 
 
 def research_package(name: str, version=None) -> PackageMetadata:
@@ -178,70 +221,77 @@ def research_package(name: str, version=None) -> PackageMetadata:
     Args:
         name (str): The name of the package to look up.
         version (str): The version of the package to look up.
-    
+
     Returns:
-        PackageMetadata: A dictionary of metadata about the package.  
+        PackageMetadata: A dictionary of metadata about the package.
     """
     try:
-        parsed_version = parse(version)
+        parse(version)
+    except TypeError as type_error:
+        logging.warning(f"Could not parse version {version}: {type_error}")
+        version = None
     except InvalidVersion as invalid_version:
         logging.warn("Invalid version: %s", invalid_version)
         version = None
 
-    pip_source_dir = Path(os.getenv("PIP_SOURCE_DIR"))
-    if pip_source_dir.is_dir() and version:
-        pip_source_file = pip_source_dir/"{}-{}.tar.gz".format(name.lower(), str(version))
-        package_metadata = PackageMetadata(name=name, version=parsed_version, source_dir=pip_source_file)
-        package_metadata.get_homepage()
-        package_metadata.get_metadata()
-        package_metadata.get_checksums()
-        package_metadata.get_download_url()
-        return package_metadata
+    try:
+        code_artifact_repo = os.getenv("AWS_CODEARTIFACT_REPOSITORY")
+        logging.warning(f"code_artifact_repo: {code_artifact_repo}")
+    except TypeError as type_error:
+        code_artifact_repo = None
 
+    if code_artifact_repo:
+        logging.warning("Using AWS CodeArtifact for package metadata")
+        package_metadata = PackageMetadata(
+            name=name,
+            version=version
+        )
+        return package_metadata.asdict()
+    else:
+        with closing(urlopen("https://pypi.io/pypi/{}/json".format(name))) as f:
+            reader = codecs.getreader("utf-8")
+            pkg_data = json.load(reader(f))
 
+        d = {}
+        d["name"] = pkg_data["info"]["name"]
+        d["homepage"] = pkg_data["info"].get("home_page", "")
+        artefact = None
+        if version:
+            for pypi_version in pkg_data["releases"]:
+                if pkg_resources.safe_version(pypi_version) == version:
+                    for version_artefact in pkg_data["releases"][pypi_version]:
+                        if version_artefact["packagetype"] == "sdist":
+                            artefact = version_artefact
+                            break
+            if artefact is None:
+                warnings.warn(
+                    "Could not find an exact version match for "
+                    "{} version {}; using newest instead".format(name, version),
+                    PackageVersionNotFoundWarning,
+                )
 
-    with closing(urlopen("https://pypi.io/pypi/{}/json".format(name))) as f:
-        reader = codecs.getreader("utf-8")
-        pkg_data = json.load(reader(f))
+        if artefact is None:  # no version given or exact match not found
+            for url in pkg_data["urls"]:
+                if url["packagetype"] == "sdist":
+                    artefact = url
+                    break
 
-    d = {}
-    d['name'] = pkg_data['info']['name']
-    d['homepage'] = pkg_data['info'].get('home_page', '')
-    artefact = None
-    if version:
-        for pypi_version in pkg_data['releases']:
-            if pkg_resources.safe_version(pypi_version) == version:
-                for version_artefact in pkg_data['releases'][pypi_version]:
-                    if version_artefact['packagetype'] == 'sdist':
-                        artefact = version_artefact
-                        break
-        if artefact is None:
-            warnings.warn("Could not find an exact version match for "
-                          "{} version {}; using newest instead".
-                          format(name, version), PackageVersionNotFoundWarning)
-
-    if artefact is None:  # no version given or exact match not found
-        for url in pkg_data['urls']:
-            if url['packagetype'] == 'sdist':
-                artefact = url
-                break
-
-    if artefact:
-        d['url'] = artefact['url']
-        if 'digests' in artefact and 'sha256' in artefact['digests']:
-            logging.debug("Using provided checksum for %s", name)
-            d['checksum'] = artefact['digests']['sha256']
-        else:
-            logging.debug("Fetching sdist to compute checksum for %s", name)
-            with closing(urlopen(artefact['url'])) as f:
-                d['checksum'] = sha256(f.read()).hexdigest()
-            logging.debug("Done fetching %s", name)
-    else:  # no sdist found
-        d['url'] = ''
-        d['checksum'] = ''
-        warnings.warn("No sdist found for %s" % name)
-    d['checksum_type'] = 'sha256'
-    return d
+        if artefact:
+            d["url"] = artefact["url"]
+            if "digests" in artefact and "sha256" in artefact["digests"]:
+                logging.debug("Using provided checksum for %s", name)
+                d["checksum"] = artefact["digests"]["sha256"]
+            else:
+                logging.debug("Fetching sdist to compute checksum for %s", name)
+                with closing(urlopen(artefact["url"])) as f:
+                    d["checksum"] = sha256(f.read()).hexdigest()
+                logging.debug("Done fetching %s", name)
+        else:  # no sdist found
+            d["url"] = ""
+            d["checksum"] = ""
+            warnings.warn("No sdist found for %s" % name)
+        d["checksum_type"] = "sha256"
+        return d
 
 
 def make_graph(pkg):
@@ -252,7 +302,7 @@ def make_graph(pkg):
     dependencies, and each value is a dictionary returned by research_package.
     (No, it's not really a graph.)
     """
-    ignore = ['argparse', 'pip', 'setuptools', 'wsgiref']
+    ignore = ["argparse", "pip", "setuptools", "wsgiref"]
     pkg_deps = recursive_dependencies(pkg_resources.Requirement.parse(pkg))
 
     dependencies = {key: {} for key in pkg_deps if key not in ignore}
@@ -260,15 +310,17 @@ def make_graph(pkg):
     versions = {package.key: package.version for package in installed_packages}
     for package in dependencies:
         try:
-            dependencies[package]['version'] = versions[package]
+            dependencies[package]["version"] = versions[package]
         except KeyError:
-            warnings.warn("{} is not installed so we cannot compute "
-                          "resources for its dependencies.".format(package),
-                          PackageNotInstalledWarning)
-            dependencies[package]['version'] = None
+            warnings.warn(
+                "{} is not installed so we cannot compute "
+                "resources for its dependencies.".format(package),
+                PackageNotInstalledWarning,
+            )
+            dependencies[package]["version"] = None
 
     for package in dependencies:
-        package_data = research_package(package, dependencies[package]['version'])
+        package_data = research_package(package, dependencies[package]["version"])
         dependencies[package].update(package_data)
 
     return OrderedDict(
@@ -283,27 +335,33 @@ def formula_for(package, also=None):
     package_name = req.project_name
 
     nodes = merge_graphs(make_graph(p) for p in [package] + also)
-    resources = [value for key, value in nodes.items()
-                 if key.lower() != package_name.lower()]
+    resources = [
+        value for key, value in nodes.items() if key.lower() != package_name.lower()
+    ]
 
     if package_name in nodes:
         root = nodes[package_name]
     elif package_name.lower() in nodes:
         root = nodes[package_name.lower()]
     else:
-        raise Exception("Could not find package {} in nodes {}".format(package, nodes.keys()))
+        raise Exception(
+            "Could not find package {} in nodes {}".format(package, nodes.keys())
+        )
 
     python = "python" if sys.version_info.major == 2 else "python3"
-    return FORMULA_TEMPLATE.render(package=root,
-                                   resources=resources,
-                                   python=python,
-                                   ResourceTemplate=RESOURCE_TEMPLATE)
+    return FORMULA_TEMPLATE.render(
+        package=root,
+        resources=resources,
+        python=python,
+        ResourceTemplate=RESOURCE_TEMPLATE,
+    )
 
 
 def resources_for(packages):
     nodes = merge_graphs(make_graph(p) for p in packages)
-    return '\n\n'.join([RESOURCE_TEMPLATE.render(resource=node)
-                        for node in nodes.values()])
+    return "\n\n".join(
+        [RESOURCE_TEMPLATE.render(resource=node) for node in nodes.values()]
+    )
 
 
 def merge_graphs(graphs):
@@ -317,49 +375,68 @@ def merge_graphs(graphs):
             else:
                 warnings.warn(
                     "Merge conflict: {l.name} {l.version} and "
-                    "{r.name} {r.version}; using the former.".
-                    format(l=result[key], r=g[key]),
-                    ConflictingDependencyWarning)
+                    "{r.name} {r.version}; using the former.".format(
+                        l=result[key], r=g[key]
+                    ),
+                    ConflictingDependencyWarning,
+                )
     return OrderedDict([k, result[k]] for k in sorted(result.keys()))
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Generate Homebrew resource stanzas for pypi packages '
-                    'and their dependencies.')
+        description="Generate Homebrew resource stanzas for pypi packages "
+        "and their dependencies."
+    )
     actions = parser.add_mutually_exclusive_group()
     actions.add_argument(
-        '--single', '-s', metavar='package', nargs='+',
-        help='Generate a resource stanza for one or more packages, '
-             'without considering dependencies.')
+        "--single",
+        "-s",
+        metavar="package",
+        nargs="+",
+        help="Generate a resource stanza for one or more packages, "
+        "without considering dependencies.",
+    )
     actions.add_argument(
-        '--formula', '-f', metavar='package',
-        help='Generate a complete formula for a pypi package with its '
-             'recursive pypi dependencies as resources.')
+        "--formula",
+        "-f",
+        metavar="package",
+        help="Generate a complete formula for a pypi package with its "
+        "recursive pypi dependencies as resources.",
+    )
     actions.add_argument(
-        '--resources', '-r', metavar='package',
-        help='Generate resource stanzas for a package and its recursive '
-             'dependencies (default).')
+        "--resources",
+        "-r",
+        metavar="package",
+        help="Generate resource stanzas for a package and its recursive "
+        "dependencies (default).",
+    )
     parser.add_argument(
-        '--also', '-a', metavar='package', action='append', default=[],
-        help='Specify an additional package that should be added to the '
-             'resource list with its recursive dependencies. May not be used '
-             'with --single. May be specified more than once.')
-    parser.add_argument('package', help=argparse.SUPPRESS, nargs='?')
+        "--also",
+        "-a",
+        metavar="package",
+        action="append",
+        default=[],
+        help="Specify an additional package that should be added to the "
+        "resource list with its recursive dependencies. May not be used "
+        "with --single. May be specified more than once.",
+    )
+    parser.add_argument("package", help=argparse.SUPPRESS, nargs="?")
     parser.add_argument(
-        '-V', '--version', action='version',
-        version='homebrew-pypi-poet {}'.format(__version__))
+        "-V",
+        "--version",
+        action="version",
+        version="homebrew-pypi-poet {}".format(__version__),
+    )
     args = parser.parse_args()
 
     if (args.formula or args.resources) and args.package:
-        print('--formula and --resources take a single argument.',
-              file=sys.stderr)
+        print("--formula and --resources take a single argument.", file=sys.stderr)
         parser.print_usage(sys.stderr)
         return 1
 
     if args.also and args.single:
-        print("Can't use --also with --single",
-              file=sys.stderr)
+        print("Can't use --also with --single", file=sys.stderr)
         parser.print_usage(sys.stderr)
         return 1
 
@@ -369,7 +446,7 @@ def main():
         for i, package in enumerate(args.single):
             data = research_package(package)
             print(RESOURCE_TEMPLATE.render(resource=data))
-            if i != len(args.single)-1:
+            if i != len(args.single) - 1:
                 print()
     else:
         package = args.resources or args.package
@@ -380,6 +457,5 @@ def main():
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())
-

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -15,22 +15,17 @@ from collections import OrderedDict
 from contextlib import closing
 from hashlib import sha256
 
-from importlib.metadata import metadata
-from pydoc import cli
 import boto3
 import json
 import logging
 import os
-import shlex
-import subprocess
 import sys
 import warnings
 from dataclasses import dataclass, field
-from typing import Optional, Type
+from typing import Optional
 
 from packaging.version import Version, parse, InvalidVersion
 
-from urlextract import URLExtract
 
 import pkg_resources
 

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -106,8 +106,6 @@ class PackageMetadata:
     source_file: Optional[Path] = None
     version: Optional[Version] = None
 
-
-
     def __init__(self, name, version) -> None:
         self.name = name
         self.package_name = self.name.replace(".", "-")
@@ -126,7 +124,8 @@ class PackageMetadata:
         return {k: v for k, v in self.__dict__.items() if k not in exclude_keys}
 
     def get_base_url(self):
-        """Get the base URL for the pip source distribution.
+        """
+        Get the base URL for the pip source distribution.
 
         Returns:
             str: The base URL for the pip source distribution.
@@ -140,14 +139,12 @@ class PackageMetadata:
         )
         return response["repositoryEndpoint"]
 
-    def get_checksum(self):
-        """Given the path to a pip source file, return the files checksum.
-
-        Args:
-            pip_source_file (Path): The path to a .tar.gz file containing a pip source distribution.
+    def get_checksum(self, hash_type="SHA256"):
+        """
+        Get the checksum for the pip source distribution.
 
         Returns:
-            str: The checksum of the pip source file.
+            str: The checksum for the pip source distribution.
         """
         client = boto3.client("codeartifact")
         response = client.list_package_version_assets(
@@ -159,13 +156,13 @@ class PackageMetadata:
             packageVersion=self.get_latest_version(),
         )
         tar_ball = [asset for asset in response["assets"] if ".tar.gz" in asset["name"]][0]
-        return tar_ball["hashes"]["SHA-256"]
+        return tar_ball["hashes"][hash_type]
     
     def get_metadata(self, key: str) -> str:
         """Get the metadata from the pip source distribution.
 
         Args:
-            key (str): The key to get from metadata/
+            key (str): The key to get from metadata
 
         Returns:
             str: The value of the key.

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -14,7 +14,6 @@ import codecs
 from collections import OrderedDict
 from contextlib import closing
 from hashlib import sha256
-from optparse import Option
 
 import boto3
 import json
@@ -30,7 +29,6 @@ from packaging.version import Version, parse, InvalidVersion
 
 import pkg_resources
 
-from pathlib import Path
 from .templates import FORMULA_TEMPLATE, RESOURCE_TEMPLATE, PRIVATE_RESOURCE_TEMPLATE
 from .version import __version__
 

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -128,8 +128,7 @@ class CodeArtifactMetadata(PackageMetadata):
         Returns:
             str: The base URL for the pip source distribution.
         """
-        client = boto3.client("codeartifact")
-        response = client.get_repository_endpoint(
+        response = self.client.get_repository_endpoint(
             domain=self.domain,
             domainOwner=self.owner,
             repository=self.repository,
@@ -153,8 +152,7 @@ class CodeArtifactMetadata(PackageMetadata):
         Returns:
             str: The checksum for the pip source distribution.
         """
-        client = boto3.client("codeartifact")
-        response = client.list_package_version_assets(
+        response = self.client.list_package_version_assets(
             domain=self.domain,
             domainOwner=self.owner,
             repository=self.repository,
@@ -177,8 +175,7 @@ class CodeArtifactMetadata(PackageMetadata):
             str: The value of the key.
         """
         try:
-            client = boto3.client("codeartifact")
-            response = client.describe_package_version(
+            response = self.client.describe_package_version(
                 domain=self.domain,
                 domainOwner=self.owner,
                 repository=self.repository,
@@ -204,8 +201,7 @@ class CodeArtifactMetadata(PackageMetadata):
             version (str) : The latest version of the package.
         """
         try:
-            client = boto3.client("codeartifact")
-            response = client.list_package_versions(
+            response = self.client.list_package_versions(
                 domain=self.domain,
                 domainOwner=self.owner,
                 repository=self.repository,

--- a/poet/templates.py
+++ b/poet/templates.py
@@ -47,3 +47,11 @@ RESOURCE_TEMPLATE = env.from_string("""\
     {{ resource.checksum_type }} "{{ resource.checksum }}"
   end
 """)
+
+
+PRIVATE_RESOURCE_TEMPLATE = env.from_string("""\
+  resource "{{ resource.name }}" do
+    url "{{ resource.url }}", :using {{ using }}
+    {{ resource.checksum_type }} "{{ resource.checksum }}"
+  end
+""")

--- a/poet/templates.py
+++ b/poet/templates.py
@@ -51,7 +51,7 @@ RESOURCE_TEMPLATE = env.from_string("""\
 
 PRIVATE_RESOURCE_TEMPLATE = env.from_string("""\
   resource "{{ resource.name }}" do
-    url "{{ resource.url }}", :using {{ using }}
+    url "{{ resource.url }}", using: {{ using }}
     {{ resource.checksum_type }} "{{ resource.checksum }}"
   end
 """)

--- a/poet/test/test_poet.py
+++ b/poet/test/test_poet.py
@@ -75,4 +75,4 @@ def test_camel_case():
 
 def test_using_value():
     result = poet("--using", "PRIVATE")
-    assert b"using: :PRIVATE" in result
+    assert b"using: PRIVATE" in result

--- a/poet/test/test_poet.py
+++ b/poet/test/test_poet.py
@@ -71,3 +71,8 @@ def test_lint(tmpdir):
 def test_camel_case():
     result = poet("-f", "magic-wormhole")
     assert b"class MagicWormhole < Formula" in result
+
+
+def test_using_value():
+    result = poet("--using", "PRIVATE")
+    assert b"using: :PRIVATE" in result

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['jinja2', 'setuptools', 'urlextract', 'packaging'],
+    install_requires=['boto3', 'jinja2', 'setuptools', 'urlextract', 'packaging'],
     entry_points={'console_scripts': [
         'poet=poet:main',
         'poet_lint=poet.lint:main',


### PR DESCRIPTION
# Use AWS Code Artifact for Metadata.

This is a POC to use AWS as a provider for the metadata. The metadata is used to populate resource blocks within the formula. These need to point code artifact URLS.

In a poc, we were downloading and then asking pip to do a bunch of things. This POC is using AWS to get all of the metadata needed.

The following PR allows the user to run the following, and get a resource block output which will be taken and redirected into the formula it is used on.

## Output

The following is the output when using this pr to generate a `resource` block.

```console
(pypi-poet)  ✘  AWS: core  homebrew-pypi-poet   aws-poc ±  poet --resources indigoag.dev.cli --using "PrivateRepoDownloadStrategy"
WARNING:root:Using private repo urls: PrivateRepoDownloadStrategy
/Users/justinrice/Documents/IndigoGit/homebrew-pypi-poet/poet/poet.py:348: PackageNotInstalledWarning: indigoag.dev.cli is not installed so we cannot compute resources for its dependencies.
  warnings.warn(
WARNING:root:A version was not specified for indigoag.dev.cli. Using latest version.
WARNING:root:Using AWS CodeArtifact repository indigoag.repository to get package metadata for indigoag.dev.cli
  resource "indigoag.dev.cli" do
    url "https://indigoag-217541722159.d.codeartifact.us-east-1.amazonaws.com/pypi/indigoag.repository/simple/indigoag-dev-cli/0.22.0/indigoag.dev.cli-0.22.0.tar.gz", using: PrivateRepoDownloadStrategy
    sha256 "176dc5db9768613ba685a4a3ebfd2aa3e264beed17f2645912b6b5c44605df9b"
  end
(pypi-poet)  AWS: core  homebrew-pypi-poet   aws-poc ± 
```

The main thing we are looking at here is the resource block that is the only thing that goes to standard out.

```ruby
  resource "indigoag.dev.cli" do
    url "https://indigoag-217541722159.d.codeartifact.us-east-1.amazonaws.com/pypi/indigoag.repository/simple/indigoag-dev-cli/0.22.0/indigoag.dev.cli-0.22.0.tar.gz", using: PrivateRepoDownloadStrategy
    sha256 "176dc5db9768613ba685a4a3ebfd2aa3e264beed17f2645912b6b5c44605df9b"
  end
```

You are now able to go to the URL defined within the resource block and put it into your web browser. You will run into auth problems, but it does auth to the private URL.

This PR aims to:
- Add CodeArtifactMetadata to handle all CodeArtifact related packages.
- Add a resource block for this new kind of resource
- Add a `--using` value which allows the user to specify a CurlDownloadStrategy which adds extra arguments to `curl` when homebrew goes to install the formula.
- Lint the current `poet/poet.py` using `black`