### PR TITLE
DO-3863: Use jinja replacement 

### DIFF
--- a/poet/poet.py
+++ b/poet/poet.py
@@ -31,7 +31,7 @@ from packaging.version import Version, parse, InvalidVersion
 
 import pkg_resources
 
-from .templates import FORMULA_TEMPLATE, RESOURCE_TEMPLATE, PRIVATE_RESOURCE_TEMPLATE
+from .templates import FORMULA_TEMPLATE, RESOURCE_TEMPLATE
 from .version import __version__
 
 try:
@@ -422,15 +422,9 @@ def formula_for(package, also=None):
 
 def resources_for(packages, using=False):
     nodes = merge_graphs(make_graph(p) for p in packages)
-    return (
-        "\n\n".join(
-            [RESOURCE_TEMPLATE.render(resource=node) for node in nodes.values()]
+    return "\n\n".join(
+            [RESOURCE_TEMPLATE.render(resource=node, using=using) for node in nodes.values()]
         )
-        if not using
-        else "\n\n".join(
-            [PRIVATE_RESOURCE_TEMPLATE.render(resource=node, using=using) for node in nodes.values()]
-        )
-    )
 
 
 def merge_graphs(graphs):

--- a/poet/templates.py
+++ b/poet/templates.py
@@ -43,15 +43,11 @@ FORMULA_TEMPLATE = env.from_string(dedent("""\
 
 RESOURCE_TEMPLATE = env.from_string("""\
   resource "{{ resource.name }}" do
+  {% if 'pythonhosted' in resource.url %}
     url "{{ resource.url }}"
-    {{ resource.checksum_type }} "{{ resource.checksum }}"
-  end
-""")
-
-
-PRIVATE_RESOURCE_TEMPLATE = env.from_string("""\
-  resource "{{ resource.name }}" do
+  {% else %}
     url "{{ resource.url }}", using: {{ using }}
+  {% endif %}
     {{ resource.checksum_type }} "{{ resource.checksum }}"
   end
 """)


### PR DESCRIPTION
# DO-3863: Confirmed jinja2 replacement works

It is a tiny cleanup for no longer needing to have resource blocks and relying on a jinja template to do what it is supposed to do. 

Now, users do not get the private repo strategy for URLs that are not an internal URL:

```ruby
  resource "websocket-client" do
      url "https://indigoag-217541722159.d.codeartifact.us-east-1.amazonaws.com/pypi/indigoag.repository/simple/websocket-client/1.3.2/websocket-client-1.3.2.tar.gz", using: PrivateRepoDownloadStrategy
      sha256 "50b21db0058f7a953d67cc0445be4b948d7fc196ecbeb8083d68d94628e4abf6"
  end

  resource "wrapt" do
      url "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
      sha256 "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"
  end

  resource "yarl" do
      url "https://files.pythonhosted.org/packages/f6/da/46d1b3d69a9a0835dabf9d59c7eb0f1600599edd421a4c5a15ab09f527e0/yarl-1.7.2.tar.gz"
      sha256 "45399b46d60c253327a460e99856752009fcee5f5d3c80b2f7c0cae1c38d56dd"
  end

  resource "zipp" do
      url "https://indigoag-217541722159.d.codeartifact.us-east-1.amazonaws.com/pypi/indigoag.repository/simple/zipp/3.8.0/zipp-3.8.0.tar.gz", using: PrivateRepoDownloadStrategy
      sha256 "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"
  end
```